### PR TITLE
TASK-1644 - Reset visible nodes when clicking redraw original tree

### DIFF
--- a/components/TreeContextMenu.react.js
+++ b/components/TreeContextMenu.react.js
@@ -136,7 +136,10 @@ const TreeContextMenu = React.memo((props) => {
       <div className="mr-ui-context-menu-item single-action">
         <button
           onClick={
-            () => tree.setSource(tree.getGraphWithoutLayout().originalSource)
+            () => {
+              tree.setSource(tree.getGraphWithoutLayout().originalSource);
+              tree.selectNode(); // Make all unselected nodes visible
+            }
           }
         >
           Redraw Original Tree


### PR DESCRIPTION
# Notes

I'm not sure this is actually the desired behaviour tbh

![redraw-selected](https://github.com/microreact/viewer/assets/5226213/faae6d49-be9a-4db3-bf0a-1f8875223fe1)
